### PR TITLE
feat/6 add inline attributes and update README

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "cc"
-version = "1.2.27"
+version = "1.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
+checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
 dependencies = [
  "shlex",
 ]
@@ -117,7 +117,7 @@ dependencies = [
 
 [[package]]
 name = "tiny-prng-wasm"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "console_error_panic_hook",
  "tiny_prng",
@@ -127,7 +127,7 @@ dependencies = [
 
 [[package]]
 name = "tiny_prng"
-version = "0.2.1"
+version = "0.2.2"
 
 [[package]]
 name = "unicode-ident"

--- a/tiny_prng/Cargo.toml
+++ b/tiny_prng/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiny_prng"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Tiny pseudo number generator set (MT, Xorshift and PCG)"

--- a/tiny_prng/README.md
+++ b/tiny_prng/README.md
@@ -77,13 +77,13 @@ See the benchmarking result for 10 million instructions of pseudo random number 
 ```shell-session
 user@localhost tiny_prng $  cargo bench  | grep -v ignored
 # (output omitted...)
-running 34 tests
-test mt64::tests::bench_mt19937_10mil          ... bench:  26,298,141.70 ns/iter (+/- 2,349,687.12)
-test mt::tests::bench_mt19937_32_10mil         ... bench:  28,526,208.40 ns/iter (+/- 345,140.73)
-test pcg::tests::bench_pcgxshrr6432_10mil      ... bench:   9,377,162.50 ns/iter (+/- 17,100.03)
-test pcg::tests::bench_pcgxslrr12864_10mil     ... bench:  15,629,216.70 ns/iter (+/- 836,248.20)
-test xorshift::tests::bench_xorshift1024_10mil ... bench:  21,973,179.10 ns/iter (+/- 875,331.16)
-test xorshift::tests::bench_xorshift64_10mil   ... bench:  18,755,408.30 ns/iter (+/- 51,057.99)
+running 31 tests
+test mt64::tests::bench_mt19937_10mil          ... bench:   7,660,233.30 ns/iter (+/- 43,981.22)
+test mt::tests::bench_mt19937_32_10mil         ... bench:   9,339,750.10 ns/iter (+/- 415,492.15)
+test pcg::tests::bench_pcgxshrr6432_10mil      ... bench:   9,416,045.80 ns/iter (+/- 589,289.98)
+test pcg::tests::bench_pcgxslrr12864_10mil     ... bench:  15,627,133.30 ns/iter (+/- 260,361.14)
+test xorshift::tests::bench_xorshift1024_10mil ... bench:  23,095,120.80 ns/iter (+/- 7,339,056.80)
+test xorshift::tests::bench_xorshift64_10mil   ... bench:  18,749,149.90 ns/iter (+/- 186,877.62)
 ```
 
 Execution environment:

--- a/tiny_prng/src/mt.rs
+++ b/tiny_prng/src/mt.rs
@@ -19,178 +19,184 @@
 
 use crate::generate_real32;
 
-const N :usize = 624;
-const N64 :usize = 312;
-const M :usize = 397;
-const M64 :usize = 156;
+const N: usize = 624;
+const N64: usize = 312;
+const M: usize = 397;
+const M64: usize = 156;
 const MATRIX_A: u64 = 0x9908b0df;
 const MATRIX_A64: u64 = 0xB5026F5AA96619E9;
 const UPPER_MASK: u64 = 0x80000000;
 const LOWER_MASK: u64 = 0x7fffffff;
-const UPPER_MASK64: u64 =  0xFFFFFFFF80000000;
+const UPPER_MASK64: u64 = 0xFFFFFFFF80000000;
 const LOWER_MASK64: u64 = 0x7FFFFFFF;
 
 pub struct Mt19937 {
-  state: [u64; N],
-  index: usize,
+    state: [u64; N],
+    index: usize,
 }
 
 impl Mt19937 {
-  fn init(&mut self, s :u64) {
-      self.state[0] = s & 0xffffffffu64;
-      self.index = 1;
-      while self.index < N {
-        self.state[self.index] = 1812433253u64 * (self.state[self.index-1] ^ (self.state[self.index-1] >> 30)) + (self.index as u64);
-        self.state[self.index] &= 0xffffffffu64;
+    #[inline]
+    fn init(&mut self, s: u64) {
+        self.state[0] = s & 0xffffffffu64;
+        self.index = 1;
+        while self.index < N {
+            self.state[self.index] = 1812433253u64 * (self.state[self.index - 1] ^ (self.state[self.index - 1] >> 30)) + (self.index as u64);
+            self.state[self.index] &= 0xffffffffu64;
+            self.index += 1;
+        }
+    }
+
+    #[inline]
+    pub fn generate(&mut self) -> u32 {
+        let mut y: u64;
+        const MAG01: [u64; 2] = [0x0u64, MATRIX_A];
+        while self.index >= N {
+            if self.index == N + 1 {
+                self.init(5489u64);
+            }
+            for kk in 0..N - M {
+                y = (self.state[kk] & UPPER_MASK) | (self.state[kk + 1] & LOWER_MASK);
+                self.state[kk] = self.state[kk + M] ^ (y >> 1) ^ MAG01[(y as usize) & 0x1usize];
+            }
+            for kk in N - M..N - 1 {
+                y = (self.state[kk] & UPPER_MASK) | (self.state[kk + 1] & LOWER_MASK);
+                self.state[kk] = self.state[kk + M - N] ^ (y >> 1) ^ MAG01[(y as usize) & 0x1usize];
+            }
+            y = (self.state[N - 1] & UPPER_MASK) | (self.state[0] & LOWER_MASK);
+            self.state[N - 1] = self.state[M - 1] ^ (y >> 1) ^ MAG01[(y as usize) & 0x1usize];
+
+            self.index = 0;
+        }
+        y = self.state[self.index];
         self.index += 1;
-      }
-  }
 
-  pub fn generate(&mut self) -> u32 {
-    let mut y :u64;
-    const MAG01: [u64;2] = [0x0u64,MATRIX_A];
-      while self.index >= N {
-        if self.index == N+1 {
-          self.init(5489u64);
+
+        // tempering
+        y ^= y >> 11;
+        y ^= (y << 7) & 0x9d2c5680;
+        y ^= (y << 15) & 0xefc60000;
+        y ^= y >> 18;
+        y as u32
+    }
+
+
+    #[inline]
+    pub fn with_array(init_key: Vec<u64>) -> Self {
+        let mut i: usize;
+        let mut j: usize;
+        let k: usize;
+        let key_len = init_key.len();
+        let mut mt = Self {
+            state: [0; N],
+            index: 0,
+        };
+        mt.init(19650218);
+        i = 1;
+        j = 0;
+        k = match N > key_len {
+            true => N,
+            false => key_len.clone(),
+        };
+        for _ in 0..k {
+            mt.state[i] = (mt.state[i] ^ ((mt.state[i - 1] ^ (mt.state[i - 1] >> 30)) * 1664525))
+                + init_key[j] + (j as u64);
+            mt.state[i] &= 0xffffffff;
+            i += 1;
+            j += 1;
+            if i >= N {
+                mt.state[0] = mt.state[N - 1];
+                i = 1;
+            }
+            if j >= key_len {
+                j = 0;
+            }
         }
-        for kk in 0..N-M {
-          y = (self.state[kk]&UPPER_MASK)|(self.state[kk+1]&LOWER_MASK);
-          self.state[kk] = self.state[kk+M] ^ (y >> 1) ^ MAG01[(y as usize) & 0x1usize];
+        for _ in 0..N - 1 {
+            mt.state[i] = (mt.state[i] ^ ((mt.state[i - 1] ^ (mt.state[i - 1] >> 30)) * 1566083941))
+                - (i as u64);
+            mt.state[i] &= 0xffffffff;
+            i += 1;
+            if i >= N {
+                mt.state[0] = mt.state[N - 1];
+                i = 1;
+            }
         }
-        for kk in N-M..N-1 {
-          y = (self.state[kk]&UPPER_MASK)|(self.state[kk+1]&LOWER_MASK);
-          self.state[kk] = self.state[kk+M-N] ^ (y >> 1) ^ MAG01[(y as usize) & 0x1usize];
-        }
-        y = (self.state[N-1]&UPPER_MASK)|(self.state[0]&LOWER_MASK);
-        self.state[N-1] = self.state[M-1] ^ (y >> 1) ^ MAG01[(y as usize) & 0x1usize];
+        mt
+    }
 
-        self.index = 0;
-      }
-      y = self.state[self.index];
-      self.index += 1;
-
-
-    // tempering
-    y ^= y >> 11;
-    y ^= (y << 7) & 0x9d2c5680;
-    y ^= (y << 15) & 0xefc60000;
-    y ^= y >> 18;
-    y as u32
-  }
-
-
-  pub fn with_array(init_key: Vec<u64>) -> Self {
-    let  mut i :usize;
-    let mut j :usize;
-    let k :usize;
-    let key_len = init_key.len();
-    let mut mt = Self {
-      state: [0;N],
-      index: 0,
-    };
-    mt.init(19650218);
-    i=1;
-    j=0;
-    k = match N>key_len {
-      true => N,
-      false => key_len.clone(),
-    };
-      for _ in 0..k {
-        mt.state[i] = (mt.state[i] ^ ((mt.state[i - 1] ^ (mt.state[i - 1] >> 30)) * 1664525))
-            + init_key[j] + (j as u64);
-        mt.state[i] &= 0xffffffff;
-        i += 1;
-        j += 1;
-        if i >= N {
-          mt.state[0] = mt.state[N - 1];
-          i = 1;
-        }
-        if j >= key_len {
-          j=0;
-        }
-      }
-      for _ in 0..N-1 {
-        mt.state[i] = (mt.state[i] ^ ((mt.state[i-1] ^ (mt.state[i-1] >> 30)) * 1566083941))
-            - (i as u64);
-        mt.state[i] &= 0xffffffff;
-        i+=1;
-        if i>=N { mt.state[0] = mt.state[N-1]; i=1; }
-      }
-    mt
-  }
-
-  generate_real32!(self);
+    generate_real32!(self);
 }
 
 #[cfg(test)]
 mod tests {
-  use crate::xorshift::{Xorshift1024star, Xorshift64};
-  use super::*;
+    use crate::xorshift::{Xorshift1024star, Xorshift64};
+    use super::*;
 
 
     #[test]
     fn test_mt_init_and_generate_with_long_array() {
-      let mut mt = Mt19937::with_array ([0x1;N+32].to_vec());
-      assert_ne!(0x1,mt.generate());
+        let mut mt = Mt19937::with_array([0x1; N + 32].to_vec());
+        assert_ne!(0x1, mt.generate());
     }
     #[test]
     fn test_mt_quality_generate_average100000() {
-      let mut mt = Mt19937::with_array (vec![0x123, 0x234, 0x345, 0x456]);
-      let mut sum :u32 = 0;
-      let max_count = 100000;
-      let acceptable_delta = u32::MAX / 100;
-      for _ in 0..max_count {
-          sum += mt.generate() / max_count;
-      }
-      let diff = match sum > u32::MAX / 2 {
-        true => sum - u32::MAX / 2 ,
-        false => u32::MAX / 2 - sum ,
-      };
-      assert_eq!(true, diff < acceptable_delta);
+        let mut mt = Mt19937::with_array(vec![0x123, 0x234, 0x345, 0x456]);
+        let mut sum: u32 = 0;
+        let max_count = 100000;
+        let acceptable_delta = u32::MAX / 100;
+        for _ in 0..max_count {
+            sum += mt.generate() / max_count;
+        }
+        let diff = match sum > u32::MAX / 2 {
+            true => sum - u32::MAX / 2,
+            false => u32::MAX / 2 - sum,
+        };
+        assert_eq!(true, diff < acceptable_delta);
     }
 
 
-  #[test]
-  fn test_quality_genrand_real1_average100000() {
-    let mut mt = Mt19937::with_array (vec![0x123, 0x234, 0x345, 0x456]);
-    let mut sum = 0.0;
-    let max_count = 100000;
-    let acceptable_delta = 1.0 / 100.0;
-    for _ in 0..max_count {
-        sum += mt.generate_real() / max_count as f64;
+    #[test]
+    fn test_quality_genrand_real1_average100000() {
+        let mut mt = Mt19937::with_array(vec![0x123, 0x234, 0x345, 0x456]);
+        let mut sum = 0.0;
+        let max_count = 100000;
+        let acceptable_delta = 1.0 / 100.0;
+        for _ in 0..max_count {
+            sum += mt.generate_real() / max_count as f64;
+        }
+        let diff = match sum > 0.5 {
+            true => sum - 0.5,
+            false => 0.5 - sum,
+        };
+        assert_eq!(true, diff < acceptable_delta);
     }
-    let diff = match sum > 0.5 {
-      true => sum - 0.5,
-      false => 0.5 - sum ,
-    };
-    assert_eq!(true, diff < acceptable_delta);
-  }
 
-  #[test]
-  fn test_quality_genrand_real2_average100000() {
-    let mut mt = Mt19937::with_array (vec![0x123, 0x234, 0x345, 0x456]);
-    let mut sum = 0.0;
-    let max_count = 100000;
-    let acceptable_delta = 1.0 / 100.0;
-    for _ in 0..max_count {
-      sum += mt.generate_real_closed() / max_count as f64;
+    #[test]
+    fn test_quality_genrand_real2_average100000() {
+        let mut mt = Mt19937::with_array(vec![0x123, 0x234, 0x345, 0x456]);
+        let mut sum = 0.0;
+        let max_count = 100000;
+        let acceptable_delta = 1.0 / 100.0;
+        for _ in 0..max_count {
+            sum += mt.generate_real_closed() / max_count as f64;
+        }
+        let diff = match sum > 0.5 {
+            true => sum - 0.5,
+            false => 0.5 - sum,
+        };
+        assert_eq!(true, diff < acceptable_delta);
     }
-    let diff = match sum > 0.5 {
-      true => sum - 0.5,
-      false => 0.5 - sum ,
-    };
-    assert_eq!(true, diff < acceptable_delta);
-  }
 
-  #[bench]
-  fn bench_mt19937_32_10mil(b: &mut test::Bencher) {
-    b.iter(|| {
-      let mut s = Mt19937::with_array(vec![0x123,0x456,0x789,0xabc,0xdef]);
-      let mut v: u32 = 0;
-      for _ in 0..10000000usize {
-        v = s.generate();
-      };
-      println!("{:x}", v);
-    })
-  }
+    #[bench]
+    fn bench_mt19937_32_10mil(b: &mut test::Bencher) {
+        b.iter(|| {
+            let mut s = Mt19937::with_array(vec![0x123, 0x456, 0x789, 0xabc, 0xdef]);
+            let mut v: u32 = 0;
+            for _ in 0..10000000usize {
+                v = s.generate();
+            };
+            println!("{:x}", v);
+        })
+    }
 }

--- a/tiny_prng/src/mt64.rs
+++ b/tiny_prng/src/mt64.rs
@@ -19,10 +19,10 @@
 
 use crate::generate_real64;
 
-const N :usize = 312;
-const M :usize = 156;
+const N: usize = 312;
+const M: usize = 156;
 const MATRIX_A: u64 = 0xB5026F5AA96619E9;
-const UPPER_MASK: u64 =  0xFFFFFFFF80000000;
+const UPPER_MASK: u64 = 0xFFFFFFFF80000000;
 const LOWER_MASK: u64 = 0x7FFFFFFF;
 
 pub struct Mt19937 {
@@ -31,33 +31,35 @@ pub struct Mt19937 {
 }
 
 impl Mt19937 {
-    fn init_genrand(&mut self, s :u64) {
+    #[inline]
+    fn init_genrand(&mut self, s: u64) {
         self.state[0] = s & 0xffffffffffffffffu64;
         self.index = 1;
         while self.index < N {
-            self.state[self.index] = 6364136223846793005u64.wrapping_mul  (self.state[self.index-1] ^ (self.state[self.index-1] >> 30)) + (self.index as u64);
+            self.state[self.index] = 6364136223846793005u64.wrapping_mul(self.state[self.index - 1] ^ (self.state[self.index - 1] >> 30)) + (self.index as u64);
             self.state[self.index] &= 0x5555555555555555u64;
             self.index += 1;
         }
     }
 
+    #[inline]
     pub fn generate(&mut self) -> u64 {
-        let mut y :u64;
-        const MAG01: [u64;2] = [0x0u64,MATRIX_A];
+        let mut y: u64;
+        const MAG01: [u64; 2] = [0x0u64, MATRIX_A];
         while self.index >= N {
-            if self.index == N+1 {
+            if self.index == N + 1 {
                 self.init_genrand(5489u64);
             }
-            for kk in 0..N-M {
-                y = (self.state[kk]&UPPER_MASK)|(self.state[kk+1]&LOWER_MASK);
-                self.state[kk] = self.state[kk+M] ^ (y >> 1) ^ MAG01[(y as usize) & 0x1usize];
+            for kk in 0..N - M {
+                y = (self.state[kk] & UPPER_MASK) | (self.state[kk + 1] & LOWER_MASK);
+                self.state[kk] = self.state[kk + M] ^ (y >> 1) ^ MAG01[(y as usize) & 0x1usize];
             }
-            for kk in N-M..N-1 {
-                y = (self.state[kk]&UPPER_MASK)|(self.state[kk+1]&LOWER_MASK);
-                self.state[kk] = self.state[kk+M-N] ^ (y >> 1) ^ MAG01[(y as usize) & 0x1usize];
+            for kk in N - M..N - 1 {
+                y = (self.state[kk] & UPPER_MASK) | (self.state[kk + 1] & LOWER_MASK);
+                self.state[kk] = self.state[kk + M - N] ^ (y >> 1) ^ MAG01[(y as usize) & 0x1usize];
             }
-            y = (self.state[N-1]&UPPER_MASK)|(self.state[0]&LOWER_MASK);
-            self.state[N-1] = self.state[M-1] ^ (y >> 1) ^ MAG01[(y as usize) & 0x1usize];
+            y = (self.state[N - 1] & UPPER_MASK) | (self.state[0] & LOWER_MASK);
+            self.state[N - 1] = self.state[M - 1] ^ (y >> 1) ^ MAG01[(y as usize) & 0x1usize];
 
             self.index = 0;
         }
@@ -74,19 +76,20 @@ impl Mt19937 {
     }
 
 
+    #[inline]
     pub fn with_array(init_key: Vec<u64>) -> Self {
-        let  mut i :usize;
-        let mut j :usize;
-        let k :usize;
+        let mut i: usize;
+        let mut j: usize;
+        let k: usize;
         let key_len = init_key.len();
         let mut mt = Self {
-            state: [0;N],
+            state: [0; N],
             index: 0,
         };
         mt.init_genrand(19650218);
-        i=1;
-        j=0;
-        k = match N>key_len {
+        i = 1;
+        j = 0;
+        k = match N > key_len {
             true => N,
             false => key_len.clone(),
         };
@@ -101,15 +104,18 @@ impl Mt19937 {
                 i = 1;
             }
             if j >= key_len {
-                j=0;
+                j = 0;
             }
         }
-        for _ in 0..N-1 {
-            mt.state[i] = (mt.state[i] ^ ((mt.state[i-1] ^ (mt.state[i-1] >> 30)) * 1566083941))
+        for _ in 0..N - 1 {
+            mt.state[i] = (mt.state[i] ^ ((mt.state[i - 1] ^ (mt.state[i - 1] >> 30)) * 1566083941))
                 - (i as u64);
             mt.state[i] &= 0xffffffff;
-            i+=1;
-            if i>=N { mt.state[0] = mt.state[N-1]; i=1; }
+            i += 1;
+            if i >= N {
+                mt.state[0] = mt.state[N - 1];
+                i = 1;
+            }
         }
         mt
     }
@@ -123,21 +129,21 @@ mod tests {
 
     #[test]
     fn test_mt64_init_and_generate_with_long_array() {
-        let mut mt = Mt19937::with_array ([0x1;N+32].to_vec());
-        assert_ne!(0x1,mt.generate());
+        let mut mt = Mt19937::with_array([0x1; N + 32].to_vec());
+        assert_ne!(0x1, mt.generate());
     }
     #[test]
     fn test_mt64_quality_generate_average100000() {
-        let mut mt = Mt19937::with_array (vec![0x123, 0x234, 0x345, 0x456]);
-        let mut sum :u64 = 0;
+        let mut mt = Mt19937::with_array(vec![0x123, 0x234, 0x345, 0x456]);
+        let mut sum: u64 = 0;
         let max_count = 100000;
         let acceptable_delta = u64::MAX / 100;
         for _ in 0..max_count {
             sum += mt.generate() / max_count;
         }
         let diff = match sum > u64::MAX / 2 {
-            true => sum - u64::MAX / 2 ,
-            false => u64::MAX / 2 - sum ,
+            true => sum - u64::MAX / 2,
+            false => u64::MAX / 2 - sum,
         };
         assert_eq!(true, diff < acceptable_delta);
     }
@@ -145,7 +151,7 @@ mod tests {
 
     #[test]
     fn test_quality_genrand_real1_average100000() {
-        let mut mt = Mt19937::with_array (vec![0x123, 0x234, 0x345, 0x456]);
+        let mut mt = Mt19937::with_array(vec![0x123, 0x234, 0x345, 0x456]);
         let mut sum = 0.0;
         let max_count = 100000;
         let acceptable_delta = 1.0 / 100.0;
@@ -154,14 +160,14 @@ mod tests {
         }
         let diff = match sum > 0.5 {
             true => sum - 0.5,
-            false => 0.5 - sum ,
+            false => 0.5 - sum,
         };
         assert_eq!(true, diff < acceptable_delta);
     }
 
     #[test]
     fn test_quality_genrand_real2_average100000() {
-        let mut mt = Mt19937::with_array (vec![0x123, 0x234, 0x345, 0x456]);
+        let mut mt = Mt19937::with_array(vec![0x123, 0x234, 0x345, 0x456]);
         let mut sum = 0.0;
         let max_count = 100000;
         let acceptable_delta = 1.0 / 100.0;
@@ -170,7 +176,7 @@ mod tests {
         }
         let diff = match sum > 0.5 {
             true => sum - 0.5,
-            false => 0.5 - sum ,
+            false => 0.5 - sum,
         };
         assert_eq!(true, diff < acceptable_delta);
     }

--- a/tiny_prng/src/pcg.rs
+++ b/tiny_prng/src/pcg.rs
@@ -18,7 +18,7 @@
 //!
 
 use std::ops::{BitAnd, BitOr, Shl, Shr};
-use crate::{generate_real64,generate_real32};
+use crate::{generate_real64, generate_real32};
 
 pub static MULTIPLIER: u64 = 1957840684519283055;
 pub static MULTIPLIER128: u128 = 0x1957840684519283055;
@@ -38,40 +38,45 @@ macro_rules! rotr64 {
     }}
 }
 pub struct PcgXshRr6432 {
-  state: u64,
+    state: u64,
 }
 
 impl PcgXshRr6432 {
-  pub fn with_seed(seed: u64) -> Self {
-    Self { state: seed }
-  }
-  pub fn generate(&mut self) -> u32 {
-      let mut x = self.state;
-    let count = (self.state >> 59) as u32;
-    self.state = x.wrapping_mul(MULTIPLIER)
-        .wrapping_add(INCREMENT);
-    x ^= x >> 18;
-    rotr32!((x>>27) as u32, count)
-  }
+    #[inline]
+    pub fn with_seed(seed: u64) -> Self {
+        Self { state: seed }
+    }
+
+    #[inline]
+    pub fn generate(&mut self) -> u32 {
+        let mut x = self.state;
+        let count = (self.state >> 59) as u32;
+        self.state = x.wrapping_mul(MULTIPLIER)
+            .wrapping_add(INCREMENT);
+        x ^= x >> 18;
+        rotr32!((x>>27) as u32, count)
+    }
     generate_real32!(self);
 }
 
 pub struct PcgXshRs6432 {
-  state: u64,
+    state: u64,
 }
 
 impl PcgXshRs6432 {
-  pub fn with_seed(seed: u64) -> Self {
-    Self { state: seed }
-  }
-  pub fn generate(&mut self) -> u32 {
-      let mut x = self.state;
-    let count = 22 + (self.state >> 61) as u32;
-    self.state = x.wrapping_mul(MULTIPLIER)
-        .wrapping_add(INCREMENT);
-    x ^= x >> 22;
-    (x >> count) as u32
-  }
+    #[inline]
+    pub fn with_seed(seed: u64) -> Self {
+        Self { state: seed }
+    }
+    #[inline]
+    pub fn generate(&mut self) -> u32 {
+        let mut x = self.state;
+        let count = 22 + (self.state >> 61) as u32;
+        self.state = x.wrapping_mul(MULTIPLIER)
+            .wrapping_add(INCREMENT);
+        x ^= x >> 22;
+        (x >> count) as u32
+    }
     generate_real32!(self);
 }
 
@@ -85,6 +90,7 @@ impl PcgXslRr {
     pub fn with_seed(seed: u128) -> Self {
         Self { state: seed }
     }
+    #[inline]
     pub fn generate(&mut self) -> u64 {
         let mut x = self.state;
         let count = (self.state >> 122) as u64;

--- a/tiny_prng/src/xorshift.rs
+++ b/tiny_prng/src/xorshift.rs
@@ -17,7 +17,6 @@
 //! }
 //! ```
 
-
 use crate::{generate_real64, generate_real32, generate_real128};
 
 pub struct Xorshift32 {
@@ -25,10 +24,12 @@ pub struct Xorshift32 {
 }
 
 impl Xorshift32 {
+    #[inline]
     pub fn with_seed(seed: u32) -> Self {
         Self { state: seed }
     }
 
+    #[inline]
     pub fn generate(&mut self) -> u32 {
         self.state ^= self.state << 13;
         self.state ^= self.state >> 17;
@@ -43,10 +44,12 @@ pub struct Xorshift64 {
 }
 
 impl Xorshift64 {
+    #[inline]
     pub fn with_seed(seed: u64) -> Self {
         Self { state: seed }
     }
 
+    #[inline]
     pub fn generate(&mut self) -> u64 {
         self.state ^= self.state << 13;
         self.state ^= self.state >> 7;
@@ -61,6 +64,7 @@ pub struct Xorshift128 {
 }
 
 impl Xorshift128 {
+    #[inline]
     pub fn with_seed(seed: u128) -> Self {
         Self {
             state: [
@@ -72,6 +76,7 @@ impl Xorshift128 {
         }
     }
 
+    #[inline]
     pub fn generate(&mut self) -> u128 {
         let mut t: u32 = self.state[3];
         let s: u32 = self.state[0];
@@ -94,9 +99,12 @@ pub struct Xorshift64star {
 }
 
 impl Xorshift64star {
+    #[inline]
     pub fn with_seed(seed: u64) -> Self {
         Self { state: seed }
     }
+
+    #[inline]
     pub fn generate(&mut self) -> u64 {
         self.state ^= self.state >> 12;
         self.state ^= self.state << 25;
@@ -111,12 +119,15 @@ pub struct Xorshift1024star {
     index: usize,
 }
 impl Xorshift1024star {
+    #[inline]
     pub fn with_seed(seed: [u64; 16]) -> Self {
         Self {
             state: seed,
             index: 0,
         }
     }
+
+    #[inline]
     pub fn generate(&mut self) -> u64 {
         let mut index = self.index;
         let s = self.state[index];
@@ -136,8 +147,8 @@ impl Xorshift1024star {
 
     generate_real64!(self);
 }
-mod tests{
-   use super::*;
+mod tests {
+    use super::*;
     #[test]
     fn test_xorshift32() {
         let mut s = Xorshift32::with_seed(1337);
@@ -302,7 +313,7 @@ mod tests{
     #[bench]
     fn bench_xorshift1024_10mil(b: &mut test::Bencher) {
         b.iter(|| {
-            let mut s = Xorshift1024star::with_seed([0x13378593;16]);
+            let mut s = Xorshift1024star::with_seed([0x13378593; 16]);
             let mut v: u64 = 0;
             for _ in 0..10000000usize {
                 v = s.generate();
@@ -310,5 +321,4 @@ mod tests{
             println!("{:x}", v);
         })
     }
-
 }

--- a/wasm_web/Cargo.toml
+++ b/wasm_web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiny-prng-wasm"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Suzume Nomura <SuzuME@ea.g1e.org>"]
 description = "PRNG in the browser stack"
 edition = "2024"

--- a/wasm_web/README.md
+++ b/wasm_web/README.md
@@ -7,13 +7,11 @@
 
 This crate provides common psuedo random number generators written in pure Rust, which include:
 
-
-| name                                 | supported mode                                                                              | cycle period                                                                                                | reference                                                                                                                                                                                                                    |
-|--------------------------------------|---------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Mersenne Twister                     | `MT19937` `MT19937_64`                                                                      | 2<sup>19937</sup>-1                                                                                         | [Saitoh and Matsumoto (1997)](https://www.math.sci.hiroshima-u.ac.jp/m-mat/MT/MT2002/emt19937ar.html)                                                                                                                        |
-| Xorshift                             | `xorshift32` <br/>`xorshift64`<br/>`xorshift128`<br/>`xorshift64*`<br/>`xorshift1024*`<br/> | 2<sup>64</sup>-1 <br/>2<sup>64</sup>-1 <br/>2<sup>128</sup>-1 <br/>2<sup>64</sup>-1 <br/>2<sup>1024</sup>-1 | [Marsaglia (2003), J. Stat. Softw. 8 (14)](https://www.jstatsoft.org/index.php/jss/article/view/v008i14/916)<br/> [Vigna (2016), ACM Trans. Math. Softw. Vol. 42 (4), 30](https://vigna.di.unimi.it/ftp/papers/xorshift.pdf) |
-| PCG (with LCG)                       | `PCG-XSL-RR-128/64` <br/>`PCG-XSH-RS-64/32` <br/>`PCG-XSH-RR-64/32`                         | 2<sup>128</sup> <br/> 2<sup>64</sup> <br/> 2<sup>64</sup>                                                   | [O'Neil (2014), HMC-CS-2014-0905](https://www.pcg-random.org/pdf/hmc-cs-2014-0905.pdf)<br/>[Reference implementation](https://github.com/imneme/pcg-c-basic)                                                                 |
-
+| name             | supported mode                                                                              | cycle period                                                                                                | reference                                                                                                                                                                                                                    |
+|------------------|---------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Mersenne Twister | `MT19937` `MT19937_64`                                                                      | 2<sup>19937</sup>-1                                                                                         | [Saitoh and Matsumoto (1997)](https://www.math.sci.hiroshima-u.ac.jp/m-mat/MT/MT2002/emt19937ar.html)                                                                                                                        |
+| Xorshift         | `xorshift32` <br/>`xorshift64`<br/>`xorshift128`<br/>`xorshift64*`<br/>`xorshift1024*`<br/> | 2<sup>64</sup>-1 <br/>2<sup>64</sup>-1 <br/>2<sup>128</sup>-1 <br/>2<sup>64</sup>-1 <br/>2<sup>1024</sup>-1 | [Marsaglia (2003), J. Stat. Softw. 8 (14)](https://www.jstatsoft.org/index.php/jss/article/view/v008i14/916)<br/> [Vigna (2016), ACM Trans. Math. Softw. Vol. 42 (4), 30](https://vigna.di.unimi.it/ftp/papers/xorshift.pdf) |
+| PCG (with LCG)   | `PCG-XSL-RR-128/64` <br/>`PCG-XSH-RS-64/32` <br/>`PCG-XSH-RR-64/32`                         | 2<sup>128</sup> <br/> 2<sup>64</sup> <br/> 2<sup>64</sup>                                                   | [O'Neil (2014), HMC-CS-2014-0905](https://www.pcg-random.org/pdf/hmc-cs-2014-0905.pdf)<br/>[Reference implementation](https://github.com/imneme/pcg-c-basic)                                                                 |
 
 This library is written in Rust but you can use it from JavaScript via its WASM binary!
 
@@ -26,7 +24,7 @@ npm install tiny-prng-wasm
 
 In the npm package, three PRNGs (and one mode for each) are supported:
 
-* `pcg` (PCG-XSL-RR-128/64) 
+* `pcg` (PCG-XSL-RR-128/64)
 * `mt64` (MT19937_64)
 * `xorshift64` (Xorshift64)
 
@@ -44,25 +42,25 @@ See the bench result for 10 million instructions of pseudo random number generat
 ```shell-session
 user@localhost tiny_prng $  cargo bench  | grep -v ignored
 # (output omitted...)
-running 34 tests
-test mt64::tests::bench_mt19937_10mil          ... bench:  26,291,179.10 ns/iter (+/- 2,051,625.47)
-test mt::tests::bench_mt19937_32_10mil         ... bench:  28,522,237.50 ns/iter (+/- 502,696.95)
-test pcg::tests::bench_pcgxshrr6432_10mil      ... bench:     937,833.40 ns/iter (+/- 5,202.71)
-test pcg::tests::bench_pcgxslrr12864_10mil     ... bench:  15,637,529.20 ns/iter (+/- 177,750.09)
-test xorshift::tests::bench_xorshift1024_10mil ... bench:  21,979,400.00 ns/iter (+/- 41,003.80)
-test xorshift::tests::bench_xorshift64_10mil   ... bench:  18,768,212.40 ns/iter (+/- 51,951.74)
+running 31 tests
+test mt64::tests::bench_mt19937_10mil          ... bench:   7,660,233.30 ns/iter (+/- 43,981.22)
+test mt::tests::bench_mt19937_32_10mil         ... bench:   9,339,750.10 ns/iter (+/- 415,492.15)
+test pcg::tests::bench_pcgxshrr6432_10mil      ... bench:   9,416,045.80 ns/iter (+/- 589,289.98)
+test pcg::tests::bench_pcgxslrr12864_10mil     ... bench:  15,627,133.30 ns/iter (+/- 260,361.14)
+test xorshift::tests::bench_xorshift1024_10mil ... bench:  23,095,120.80 ns/iter (+/- 7,339,056.80)
+test xorshift::tests::bench_xorshift64_10mil   ... bench:  18,749,149.90 ns/iter (+/- 186,877.62)
 ```
 
 Execution environment:
 
-* OS: macOS Sequoia 15.5 
+* OS: macOS Sequoia 15.5
 * CPU: arm64 (Apple M1)
 * Memory: 8GB
 
 > [!NOTE]
 > This result is measured with benchmark tests in the library.
-> We are planning further performance evaluations and investigations in the future, in more different execution environments with variety of benchmarking conditions.
-
+> We are planning further performance evaluations and investigations in the future, in more different execution
+> environments with variety of benchmarking conditions.
 
 ## Frontend Benchmarking
 


### PR DESCRIPTION
The effect of `inline` attributes are limited to xorshift and pcg. But performances of MT family are improved.
See updated README for more detail.